### PR TITLE
feat: Per-provider `KineticLib.AuthTokenStore`

### DIFF
--- a/lib/kinetic_lib/auth_token_store.ex
+++ b/lib/kinetic_lib/auth_token_store.ex
@@ -2,9 +2,10 @@ defmodule KineticLib.AuthTokenStore do
   # This is the first project to be created to share our token store implementation.
 
   @moduledoc """
-  The AuthTokenStore is an authentication token storage server that will hold
-  onto authentication tokens for external services so that requests can be made
-  to those services without requiring a new authentication token request.
+  The AuthTokenStore is an authentication token storage server facade that will
+  hold authentication tokens for external services so that requests can be made
+  to those services without requiring a new authentication token request, until
+  they expire.
 
   Tokens are provided by a module that implements the
   `KineticLib.AuthTokenStore.Provider` behaviour.
@@ -14,16 +15,8 @@ defmodule KineticLib.AuthTokenStore do
   [1]: https://github.com/peburrows/goth/blob/master/lib/goth/token_store.ex
   """
 
-  use GenServer
-
-  alias KineticLib.AuthTokenStore.StoredToken
-
-  defmodule State do
-    @moduledoc false
-
-    # The buffer interval is seconds.
-    defstruct tokens: %{}, buffer_interval: 30
-  end
+  alias KineticLib.AuthTokenStore.ProviderStore
+  alias KineticLib.AuthTokenStore.Supervisor, as: AuthSupervisor
 
   @doc """
   Request a token for the given provider and credentials. If the token is
@@ -34,170 +27,40 @@ defmodule KineticLib.AuthTokenStore do
   using token refresh capabilities if supported by the provider, or by normal
   token acquisition.
   """
-  def request(store \\ __MODULE__, provider, credentials, timeout \\ 5000) do
-    timeout =
-      case function_exported?(provider, :timeout, 0) && provider.timeout() do
-        offset when is_integer(offset) -> timeout + offset
-        _ -> timeout
-      end
-
-    GenServer.call(store, {:request_token, provider, credentials}, timeout)
-  catch
-    :exit,
-    {:timeout, {GenServer, :call, [store, {:request_token, provider, credentials}, timeout]}} ->
-      KineticLib.record_error_message(
-        "#{store}: timeout requesting auth token for #{provider}",
-        %{credentials: provider.clean_credentials(credentials), timeout: timeout}
-      )
-
-      {:error, :timeout}
+  def request(provider, credentials, timeout \\ 5000) do
+    case provider_store(provider) do
+      {:ok, store} -> ProviderStore.request(store, provider, credentials, timeout)
+      error -> error
+    end
   end
 
   @doc """
   Releases (invalidates) a token for the given provider and credentials.
   """
-  def release(store \\ __MODULE__, provider, credentials) do
-    GenServer.call(store, {:release_token, provider, credentials})
-  catch
-    :exit,
-    {:timeout, {GenServer, :call, [store, {:release_token, provider, credentials}, timeout]}} ->
-      KineticLib.record_error_message(
-        "#{store}: timeout releasing auth token for #{provider}",
-        %{credentials: provider.clean_credentials(credentials), timeout: timeout}
-      )
-
-      :ok
-  end
-
-  @doc false
-  def filter_genserver_call_timeout([store, {:request_token, provider, credentials}, timeout]) do
-    [store, {:request_token, provider, provider.clean_credentials(credentials)}, timeout]
-  end
-
-  def filter_genserver_call_timeout([store, {:release_token, provider, credentials}, timeout]) do
-    [store, {:request_token, provider, provider.clean_credentials(credentials)}, timeout]
-  end
-
-  def filter_genserver_call_timeout(_args), do: :ignore
-
-  @doc false
-  def start_link(options \\ []) do
-    KineticLib.Logger.add_primary_filter(
-      :auth_token_store_filter,
-      {:genserver_call_timeout, &__MODULE__.filter_genserver_call_timeout/1}
-    )
-
-    GenServer.start_link(
-      __MODULE__,
-      %State{buffer_interval: Keyword.get(options, :buffer_interval, 30)},
-      name: Keyword.get(options, :name, __MODULE__)
-    )
-  end
-
-  @doc false
-  def init(state) do
-    {:ok, state}
-  end
-
-  @doc false
-  def handle_call({:request_token, provider, credentials}, _from, state) do
-    case find_token(state, provider, credentials) do
-      {:ok, %StoredToken{} = token} ->
-        {:reply, {:ok, token}, state}
-
-      _ ->
-        case acquire_token(state, provider, credentials) do
-          {:ok, %StoredToken{} = token, state} ->
-            {:reply, {:ok, token}, state}
-
-          {:error, reason} ->
-            {:reply, {:error, reason}, state}
-        end
+  def release(provider, credentials) do
+    case provider_store(provider) do
+      {:ok, store} -> ProviderStore.release(store, provider, credentials)
+      error -> error
     end
   end
 
-  @doc false
-  def handle_call({:release_token, provider, credentials}, _from, state) do
-    {:reply, :ok, %{state | tokens: Map.delete(state.tokens, {provider, credentials})}}
-  end
-
-  @doc false
-  def handle_info({:refresh_token, token}, state) do
-    result =
-      if function_exported?(token.provider, :refresh_token, 1) do
-        refresh_token(state, token)
-      else
-        acquire_token(state, token.provider, token.credentials)
-      end
-
-    case result do
-      {:ok, _token, state} ->
-        {:noreply, state}
-
-      {:ok, state} ->
-        {:noreply, state}
-
-      _ ->
-        {:noreply,
-         %{state | tokens: Map.delete(state.tokens, {token.provider, token.credentials})}}
-    end
-  end
-
-  defp acquire_token(state, provider, credentials) do
-    case provider.request_token(credentials) do
-      {:ok, %StoredToken{} = token} ->
-        token = %{token | provider: provider, timestamp: DateTime.utc_now()}
-        schedule_refresh(state, token)
-        {:ok, token, add_token(state, token)}
-
-      {:error, reason} ->
-        {:error, reason}
-
-      _ ->
-        {:error, :unknown}
-    end
-  end
-
-  defp refresh_token(state, %StoredToken{provider: provider} = token) do
-    case provider.refresh_token(token) do
-      {:ok, %StoredToken{} = token} ->
-        token = %{token | provider: provider, timestamp: DateTime.utc_now()}
-        schedule_refresh(state, token)
-        {:ok, add_token(state, token)}
-
-      {:error, reason} ->
-        {:error, reason}
-
-      _ ->
-        {:error, :unknown}
-    end
-  end
-
-  defp schedule_refresh(state, token) do
-    if is_number(token.ttl) do
-      seconds_elapsed = DateTime.diff(DateTime.utc_now(), token.timestamp)
-      seconds_wait = Enum.max([0, token.ttl - seconds_elapsed - state.buffer_interval])
-      Process.send_after(self(), {:refresh_token, token}, seconds_wait * 1000)
-    end
-  end
-
-  defp add_token(state, token) do
-    %{state | tokens: Map.put(state.tokens, {token.provider, token.credentials}, token)}
-  end
-
-  defp find_token(state, provider, credentials) do
-    token = Map.get(state.tokens, {provider, credentials})
-
-    case token do
+  defp provider_store(provider) do
+    case Process.whereis(provider) do
       nil ->
-        {:error, :not_found}
+        spec =
+          [name: provider]
+          |> ProviderStore.child_spec()
+          |> Supervisor.child_spec(id: provider)
 
-      token ->
-        if StoredToken.valid?(token) do
-          {:ok, token}
-        else
-          {:error, :not_valid}
+        case Supervisor.start_child(AuthSupervisor, spec) do
+          {:ok, provider_store} -> {:ok, provider_store}
+          {:ok, provider_store, _info} -> {:ok, provider_store}
+          {:error, {:already_started, provider_store}} -> {:ok, provider_store}
+          {:error, reason} -> {:error, reason}
         end
+
+      provider_store ->
+        {:ok, provider_store}
     end
   end
 end

--- a/lib/kinetic_lib/auth_token_store/provider_store.ex
+++ b/lib/kinetic_lib/auth_token_store/provider_store.ex
@@ -1,0 +1,199 @@
+defmodule KineticLib.AuthTokenStore.ProviderStore do
+  @moduledoc """
+  `AuthTokenStore.ProviderStore` is an authentication token storage server that
+  will hold authentication tokens for a specific token authentication provider.
+
+  Tokens are provided by a module that implements the
+  `KineticLib.AuthTokenStore.Provider` behaviour.
+
+  See `KineticLib.AuthTokenStore` for more information.
+  """
+
+  use GenServer
+
+  alias KineticLib.AuthTokenStore.StoredToken
+
+  defmodule State do
+    @moduledoc false
+
+    # The buffer interval is seconds.
+    defstruct tokens: %{}, buffer_interval: 30
+  end
+
+  @doc """
+  Request a token for the given provider and credentials. If the token is
+  found in the state and has not yet expired, the existing token will be
+  returned. Otherwise, uses the token provider to obtain the credentials.
+
+  Tokens with timeouts will automatically be refreshed with the provider,
+  using token refresh capabilities if supported by the provider, or by normal
+  token acquisition.
+  """
+  def request(store \\ __MODULE__, provider, credentials, timeout \\ 5000) do
+    timeout =
+      case function_exported?(provider, :timeout, 0) && provider.timeout() do
+        offset when is_integer(offset) -> timeout + offset
+        _ -> timeout
+      end
+
+    GenServer.call(store, {:request_token, provider, credentials}, timeout)
+  catch
+    :exit,
+    {:timeout, {GenServer, :call, [^store, {:request_token, provider, credentials}, timeout]}} ->
+      KineticLib.record_error_message(
+        "#{KineticLib.process_name(store)}: timeout requesting auth token for #{provider}",
+        %{credentials: provider.clean_credentials(credentials), timeout: timeout}
+      )
+
+      {:error, :timeout}
+  end
+
+  @doc """
+  Releases (invalidates) a token for the given provider and credentials.
+  """
+  def release(store \\ __MODULE__, provider, credentials) do
+    GenServer.call(store, {:release_token, provider, credentials})
+  catch
+    :exit,
+    {:timeout, {GenServer, :call, [^store, {:release_token, provider, credentials}, timeout]}} ->
+      KineticLib.record_error_message(
+        "#{KineticLib.process_name(store)}: timeout releasing auth token for #{provider}",
+        %{credentials: provider.clean_credentials(credentials), timeout: timeout}
+      )
+
+      :ok
+  end
+
+  @doc false
+  def start_link(options \\ []) do
+    name = Keyword.get(options, :name, __MODULE__)
+
+    KineticLib.Logger.add_primary_filter(
+      name,
+      {:genserver_call_timeout,
+       fn
+         [^name, {:request_token, provider, credentials}, timeout] ->
+           [name, {:request_token, provider, provider.clean_credentials(credentials)}, timeout]
+
+         [^name, {:release_token, provider, credentials}, timeout] ->
+           [name, {:request_token, provider, provider.clean_credentials(credentials)}, timeout]
+
+         _anything_else ->
+           :ignore
+       end}
+    )
+
+    GenServer.start_link(
+      __MODULE__,
+      %State{buffer_interval: Keyword.get(options, :buffer_interval, 30)},
+      name: name
+    )
+  end
+
+  @doc false
+  def init(state) do
+    {:ok, state}
+  end
+
+  @doc false
+  def handle_call({:request_token, provider, credentials}, _from, state) do
+    case find_token(state, provider, credentials) do
+      {:ok, %StoredToken{} = token} ->
+        {:reply, {:ok, token}, state}
+
+      _ ->
+        case acquire_token(state, provider, credentials) do
+          {:ok, %StoredToken{} = token, state} ->
+            {:reply, {:ok, token}, state}
+
+          {:error, reason} ->
+            {:reply, {:error, reason}, state}
+        end
+    end
+  end
+
+  @doc false
+  def handle_call({:release_token, provider, credentials}, _from, state) do
+    {:reply, :ok, %{state | tokens: Map.delete(state.tokens, {provider, credentials})}}
+  end
+
+  @doc false
+  def handle_info({:refresh_token, token}, state) do
+    result =
+      if function_exported?(token.provider, :refresh_token, 1) do
+        refresh_token(state, token)
+      else
+        acquire_token(state, token.provider, token.credentials)
+      end
+
+    case result do
+      {:ok, _token, state} ->
+        {:noreply, state}
+
+      {:ok, state} ->
+        {:noreply, state}
+
+      _ ->
+        {:noreply,
+         %{state | tokens: Map.delete(state.tokens, {token.provider, token.credentials})}}
+    end
+  end
+
+  defp acquire_token(state, provider, credentials) do
+    case provider.request_token(credentials) do
+      {:ok, %StoredToken{} = token} ->
+        token = %{token | provider: provider, timestamp: DateTime.utc_now()}
+        schedule_refresh(state, token)
+        {:ok, token, add_token(state, token)}
+
+      {:error, reason} ->
+        {:error, reason}
+
+      _ ->
+        {:error, :unknown}
+    end
+  end
+
+  defp refresh_token(state, %StoredToken{provider: provider} = token) do
+    case provider.refresh_token(token) do
+      {:ok, %StoredToken{} = token} ->
+        token = %{token | provider: provider, timestamp: DateTime.utc_now()}
+        schedule_refresh(state, token)
+        {:ok, add_token(state, token)}
+
+      {:error, reason} ->
+        {:error, reason}
+
+      _ ->
+        {:error, :unknown}
+    end
+  end
+
+  defp schedule_refresh(state, token) do
+    if is_number(token.ttl) do
+      seconds_elapsed = DateTime.diff(DateTime.utc_now(), token.timestamp)
+      seconds_wait = Enum.max([0, token.ttl - seconds_elapsed - state.buffer_interval])
+      Process.send_after(self(), {:refresh_token, token}, seconds_wait * 1000)
+    end
+  end
+
+  defp add_token(state, token) do
+    %{state | tokens: Map.put(state.tokens, {token.provider, token.credentials}, token)}
+  end
+
+  defp find_token(state, provider, credentials) do
+    token = Map.get(state.tokens, {provider, credentials})
+
+    case token do
+      nil ->
+        {:error, :not_found}
+
+      token ->
+        if StoredToken.valid?(token) do
+          {:ok, token}
+        else
+          {:error, :not_valid}
+        end
+    end
+  end
+end

--- a/lib/kinetic_lib/auth_token_store/supervisor.ex
+++ b/lib/kinetic_lib/auth_token_store/supervisor.ex
@@ -1,6 +1,6 @@
 defmodule KineticLib.AuthTokenStore.Supervisor do
   @moduledoc """
-  A supervisor for the server behind `KineticLib.AuthTokenStore`.
+  A supervisor for `KineticLib.AuthTokenStore.ProviderStore`s.
   """
 
   use Supervisor
@@ -9,7 +9,7 @@ defmodule KineticLib.AuthTokenStore.Supervisor do
     Supervisor.start_link(__MODULE__, options, name: __MODULE__)
   end
 
-  def init(options) do
-    Supervisor.init([{KineticLib.AuthTokenStore, options}], strategy: :one_for_one)
+  def init(_options) do
+    Supervisor.init([], strategy: :one_for_one)
   end
 end


### PR DESCRIPTION
Increases the responsiveness of `AuthTokenStore`. Currently, there is
one `AuthTokenStore` for all token providers and credentials
combinations. This can lead to cascading `GenServer` call timeouts.

As an example, assume two different token providers:

- A, with an average 2 second response time
- B, with an average 7 second response time

The default request timeout is 5 seconds. Because we know that B takes
longer, its requests always have a timeout value of 8 seconds.

If both A and B need refreshing at the same time, then we have the
following possible negative cases:

- (A then B): A succeeds in 2 seconds, but B times out because the time
  it spent _waiting_ for A to complete is counted in its time elapsed.
- (B then A): B succeeds in 6 seconds, but A times out because 6 seconds
  is longer than the default 5 second timeout.

This change moves the provider retrieval logic from `AuthTokenStore` to
`AuthTokenStore.ProviderStore`. The delegating functions in
`AuthTokenStore` are used to start a per-provider named
`AuthTokenSTore.ProviderStore`, which means that only requests for the
_same_ provider can result in a possible timeout chain.

That is:

- If a request is made for A, the request is made to the ProviderStore
  instance _for_ A.
- If a request is made for B, the request is made to the ProviderStore
  instance _for_ B.

It is still possible for two requests to B to time out in this scenario,
   especially if they are for different credentials, but this can be
   mitigated by implementing an extended timeout in the `TokenProvider`.

In cases where this happens frequently, the recommendation is to create
a secondary provider that delegates token retrieval calls to the
canonical implementation.
